### PR TITLE
Add Transitional Animation For Error Message

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bootstrap": "*",
     "font-awesome-webpack": "*",
     "classnames": "*",
+    "react-addons-css-transition-group": "*",
     "fuzzy": "*",
     "colr": "*"
   },

--- a/src/javascripts/util.js
+++ b/src/javascripts/util.js
@@ -1,6 +1,7 @@
-var React = require("react")
-var {div, span, label} = React.DOM
-var cx = require("classnames")
+let React = require("react")
+let {div, span, label} = React.DOM
+let cx = require("classnames")
+let transitionGroup = React.createFactory(React.addons.CSSTransitionGroup)
 
 module.exports = {
   errorList(errors) {
@@ -9,8 +10,19 @@ module.exports = {
   },
 
   error(msg, i=0) {
-    return span({className: "help-block", key: `error-${i}`},
-      React.DOM.i({className: "fa fa-exclamation-circle"}, ` ${msg}`),
+    let transtionAttrs = {
+      transitionName: "errorLabel",
+      transitionAppear: true,
+      transitionEnterTimeout: 0,
+      transitionLeaveTimeout: 0,
+    }
+    return transitionGroup(transtionAttrs,
+      span({className: "help-block", key: `error-${i}`},
+        React.DOM.i({
+          className: "fa fa-exclamation-circle",
+          key: `error-errorLabel-${i}`,
+        }, ` ${msg}`),
+      )
     )
   },
 

--- a/src/stylesheets/components/errors.styl
+++ b/src/stylesheets/components/errors.styl
@@ -1,17 +1,17 @@
 @keyframes friggingBootstrapErrorHeight
   0%
-    max-height: 0px
+    max-height 0px
   100%
-    max-height: 300px
+    max-height 300px
 
 @keyframes friggingBootstrapErrorOpacity
   0%
-    opacity: 0
+    opacity 0
   100%
-    opacity: 1
+    opacity 1
 
 .frigb-error
-  animation friggingBootstrapErrorHeight, 1.4s, linear, 0s, 1, normal, both
+  animation friggingBootstrapErrorHeight 2.5s linear 0s 1 normal both
   .alert
-    animation friggingBootstrapErrorOpacity, 0.6s, linear, 0s, 1, normal, both
-  margin: 0 0 15px 0
+    animation friggingBootstrapErrorOpacity 0.6s linear 0s 1 normal both
+  margin 0 0 15px 0

--- a/src/stylesheets/components/errors.styl
+++ b/src/stylesheets/components/errors.styl
@@ -15,3 +15,17 @@
   .alert
     animation friggingBootstrapErrorOpacity 0.6s linear 0s 1 normal both
   margin 0 0 15px 0
+
+.errorLabel-appear
+  opacity 0
+  max-height 0px
+  margin-top 0px
+  margin-bottom 0px
+  transition max-height 0.7s ease, margin-top 0.5s ease, margin-bottom 0.5s ease, opacity 0.5s ease
+
+.errorLabel-appear.errorLabel-appear-active
+  opacity 1
+  max-height 30px
+  margin-top 5px
+  margin-bottom 10px
+


### PR DESCRIPTION
Add transitional animation for the error messages because there are some cases such as if a field has auto focus and require. The user would have to click on a button twice to activated it. As the error message appears to suddenly.

Also, fix error block animation to work again
