### PR TITLE
Add Focus To Attach To Switch Component

### DIFF
--- a/src/javascripts/components/switch.js
+++ b/src/javascripts/components/switch.js
@@ -94,7 +94,7 @@ export default class Switch extends React.Component {
 
   render() {
     return (
-      <div className={cx(sizeClassNames(this.props))}>
+      <div className={cx(sizeClassNames(this.props))} tabIndex={0}>
         <div className={formGroupCx(this.props)}>
           {label(this.props)}
           {saveList(this.props.saved)}


### PR DESCRIPTION
Attach focus to the switch component if user clicks on the component because components, in a modal, in another modal, will only work if the component is able use focus. This is because the layer on top of the first modal will always close when it is click.
