### PR TITLE
Fix submit layout

### DIFF
--- a/src/javascripts/components/color/hue_slider.js
+++ b/src/javascripts/components/color/hue_slider.js
@@ -2,10 +2,9 @@ let React = require("react")
 let ReactDOM = require("react-dom")
 let Colr = require('colr')
 let draggable = require('./higher_order_components/draggable.js')
-let { div } = React.DOM
 
 @draggable({
-  updateClientCoords({clientX, clientY}) {
+  updateClientCoords({clientY}) {
     let rect = ReactDOM.findDOMNode(this).getBoundingClientRect()
     let hue = this.getScaledValue((rect.bottom - clientY) / rect.height)
     let colr = Colr.fromHsv(hue, this.props.hsv.s, this.props.hsv.v)

--- a/src/javascripts/components/submit.js
+++ b/src/javascripts/components/submit.js
@@ -11,6 +11,12 @@ export default class Submit extends React.Component {
     block: false,
   })
 
+  static contextTypes = {
+    frigForm: React.PropTypes.shape({
+      layout: React.PropTypes.string.isRequired,
+    }).isRequired,
+  }
+
   _inputCx() {
     let optionalClasses = {
       "btn-block": this.props.block,

--- a/src/javascripts/components/submit.js
+++ b/src/javascripts/components/submit.js
@@ -32,7 +32,8 @@ export default class Submit extends React.Component {
   }
 
   _submitContainerCx() {
-    let {layout, block} = this.props
+    const {block} = this.props
+    const {layout} = this.context.frigForm
     if (layout !== "horizontal") return ""
     return cx({
       "col-sm-9 col-sm-offset-3": block === false,


### PR DESCRIPTION
As of v0.9.x, Frig has changed to pass `layout` via `context` instead of `props`.

frigging-bootstrap's `submit.js` was not updated to account for this. This means styles aren't being correctly applied for submit buttons.

Fix is to get `layout` from `context`, and also opt into `context` by defining `contextTypes`.
