### PR TITLE
<Errors> component's props.errors must be an array

### DIFF
--- a/src/javascripts/components/errors.js
+++ b/src/javascripts/components/errors.js
@@ -5,27 +5,29 @@ export default class Errors extends React.Component {
 
   static defaultProps = require("../default_props.js")
 
+  static propTypes = {
+    errors: React.PropTypes.array.isRequired,
+  }
+
   render() {
+    const {errors} = this.props
     return (
       <div>
         {
-          (this.props.errors||[]).map((error) => {
-            return (
-              <div className="col-xs-12" key={`error-${error}`}>
-                <div className="frigb-error" ref={`error-${error}`}>
-                  <div className="alert alert-danger">
-                    <i className="fa fa-exclamation-circle"/>
-                    <span className="sr-only">Error:</span>
-                    {` ${error}`}
-                    <div className="clearfix"/>
-                  </div>
+          errors.map((error) =>
+            <div className="col-xs-12" key={`error-${error}`}>
+              <div className="frigb-error" ref={`error-${error}`}>
+                <div className="alert alert-danger">
+                  <i className="fa fa-exclamation-circle"/>
+                  <span className="sr-only">Error:</span>
+                  {` ${error}`}
+                  <div className="clearfix"/>
                 </div>
               </div>
-            )
-          })
+            </div>
+          )
         }
       </div>
     )
   }
-
 }


### PR DESCRIPTION
After https://github.com/frig-js/frig/pull/35, `props.errors` (passed to us from Frig's `<FormErrorList/>`) will always be an array. Enforce this via propTypes.
