### PR TITLE
Add Default Prop Types

### DIFF
--- a/src/js/components/checkbox.js
+++ b/src/js/components/checkbox.js
@@ -9,6 +9,7 @@ import {
   sizeClassNames,
   formGroupCx,
 } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Boolean
 export default class Checkbox extends React.Component {
@@ -16,25 +17,7 @@ export default class Checkbox extends React.Component {
 
   static defaultProps = require('../default_props.js')
 
-  static propTypes = {
-    inputHtml: React.PropTypes.object.isRequired,
-    labelHtml: React.PropTypes.array.isRequired,
-
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    key: React.PropTypes.string,
-    label: React.PropTypes.string,
-
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+  static propTypes = defaultPropTypes
 
   _inputHtml() {
     return Object.assign({}, this.props.inputHtml, {

--- a/src/js/components/checkbox.js
+++ b/src/js/components/checkbox.js
@@ -9,13 +9,14 @@ import {
   sizeClassNames,
   formGroupCx,
 } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Boolean
 export default class Checkbox extends React.Component {
   static displayName = 'FriggingBootstrap.Checkbox'
 
-  static defaultProps = require('../default_props.js')
+  static defaultProps = defaultProps
 
   static propTypes = defaultPropTypes
 

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -11,6 +11,7 @@ import Label from './label'
 import ColorMap from './color/map'
 import HueSlider from './color/hue_slider'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Focusable
 export default class Color extends React.Component {
@@ -18,22 +19,11 @@ export default class Color extends React.Component {
 
   static defaultProps = Object.assign(require('../default_props.js'))
 
-  static propTypes = {
-    inputHtml: React.PropTypes.object,
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    focused: React.PropTypes.bool,
-
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      focused: React.PropTypes.bool,
+    }
+  )
 
   constructor() {
     super()

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -11,13 +11,14 @@ import Label from './label'
 import ColorMap from './color/map'
 import HueSlider from './color/hue_slider'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Focusable
 export default class Color extends React.Component {
   static displayName = 'FriggingBootstrap.Color'
 
-  static defaultProps = Object.assign(require('../default_props.js'))
+  static defaultProps = defaultProps
 
   static propTypes = Object.assign({},
     defaultPropTypes, {

--- a/src/js/components/color/hue_slider.js
+++ b/src/js/components/color/hue_slider.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import Colr from 'colr'
 import draggable from './higher_order_components/draggable.js'
+import defaultProps from '../../default_props.js'
 
 @draggable({
   // See this for the below issue with eslint and higher order components - https://github.com/yannickcr/eslint-plugin-react/issues/322
@@ -15,7 +16,8 @@ import draggable from './higher_order_components/draggable.js'
 })
 export default class HueSlider extends React.Component {
   static displayName = 'HueSlider'
-  static defaultProps = require('../../default_props.js')
+
+  static defaultProps = defaultProps
 
   static propTypes = {
     hsv: React.PropTypes.shape({

--- a/src/js/components/color/map.js
+++ b/src/js/components/color/map.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import Colr from 'colr'
 import cx from 'classnames'
 import draggable from './higher_order_components/draggable.js'
+import defaultProps from '../../default_props.js'
 
 @draggable({
   // See this for the below issue with eslint and higher order components - https://github.com/yannickcr/eslint-plugin-react/issues/322
@@ -19,7 +20,8 @@ import draggable from './higher_order_components/draggable.js'
 })
 export default class ColorMap extends React.Component {
   static displayName = 'ColorMap'
-  static defaultProps = require('../../default_props.js')
+
+  static defaultProps = defaultProps
 
   static propTypes = {
     hsv: React.PropTypes.shape({

--- a/src/js/components/file.js
+++ b/src/js/components/file.js
@@ -6,12 +6,13 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 export default class FileInput extends React.Component {
   static displayName = 'FriggingBootstrap.FileInput'
 
-  static defaultProps = Object.assign(require('../default_props.js'), {
+  static defaultProps = Object.assign(defaultProps, {
     prefix: undefined,
     suffix: undefined,
   })

--- a/src/js/components/file.js
+++ b/src/js/components/file.js
@@ -6,6 +6,7 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 export default class FileInput extends React.Component {
   static displayName = 'FriggingBootstrap.FileInput'
@@ -15,24 +16,12 @@ export default class FileInput extends React.Component {
     suffix: undefined,
   })
 
-  static propTypes = {
-    inputHtml: React.PropTypes.object,
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    className: React.PropTypes.string,
-    prefix: React.PropTypes.string,
-    suffix: React.PropTypes.string,
-
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      prefix: React.PropTypes.string,
+      suffix: React.PropTypes.string,
+    }
+  )
 
   _input() {
     const inputProps = Object.assign({}, this.props.inputHtml, {

--- a/src/js/components/form_error_list.js
+++ b/src/js/components/form_error_list.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import defaultProps from '../default_props.js'
 
 export default class FormErrorList extends React.Component {
   static displayName = 'FriggingBootstrap.Errors'
 
-  static defaultProps = require('../default_props.js')
+  static defaultProps = defaultProps
 
   static propTypes = {
     errors: React.PropTypes.array.isRequired,

--- a/src/js/components/input.js
+++ b/src/js/components/input.js
@@ -9,32 +9,18 @@ import {
   formGroupCx,
   inputContainerCx,
 } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 export default class Input extends React.Component {
   static displayName = 'FriggingBootstrap.Input'
 
-  static propTypes = {
-    inputHtml: React.PropTypes.shape({
-      type: React.PropTypes.string.isRequired,
-    }).isRequired,
-    inputWrapper: React.PropTypes.func.isRequired,
-
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    className: React.PropTypes.string,
-    prefix: React.PropTypes.string,
-    suffix: React.PropTypes.string,
-
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      inputWrapper: React.PropTypes.func.isRequired,
+      prefix: React.PropTypes.string,
+      suffix: React.PropTypes.string,
+    }
+  )
 
   static defaultProps = Object.assign(require('../default_props.js'), {
     // Bootstrap input addon texts

--- a/src/js/components/input.js
+++ b/src/js/components/input.js
@@ -9,6 +9,7 @@ import {
   formGroupCx,
   inputContainerCx,
 } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 export default class Input extends React.Component {
@@ -22,7 +23,7 @@ export default class Input extends React.Component {
     }
   )
 
-  static defaultProps = Object.assign(require('../default_props.js'), {
+  static defaultProps = Object.assign(defaultProps, {
     // Bootstrap input addon texts
     prefix: undefined,
     suffix: undefined,

--- a/src/js/components/number.js
+++ b/src/js/components/number.js
@@ -7,6 +7,7 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 export default class Number extends React.Component {
   static displayName = 'FriggingBootstrap.Number'
@@ -15,22 +16,11 @@ export default class Number extends React.Component {
     format: '0,0[.][00]',
   })
 
-  static propTypes = {
-    inputHtml: React.PropTypes.object,
-    format: React.PropTypes.string,
-
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      format: React.PropTypes.string,
+    }
+  )
 
   state = {
     formattedValue: '',

--- a/src/js/components/number.js
+++ b/src/js/components/number.js
@@ -7,12 +7,13 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 export default class Number extends React.Component {
   static displayName = 'FriggingBootstrap.Number'
 
-  static defaultProps = Object.assign(require('../default_props.js'), {
+  static defaultProps = Object.assign(defaultProps, {
     format: '0,0[.][00]',
   })
 

--- a/src/js/components/select.js
+++ b/src/js/components/select.js
@@ -7,6 +7,7 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 export default class Select extends React.Component {
   static displayName = 'FriggingBootstrap.Select'
@@ -15,25 +16,15 @@ export default class Select extends React.Component {
     options: {},
   })
 
-  static propTypes = {
-    inputHtml: React.PropTypes.object,
-    options: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object,
-      React.PropTypes.string,
-    ]),
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      options: React.PropTypes.oneOfType([
+        React.PropTypes.array,
+        React.PropTypes.object,
         React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
       ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+    }
+  )
 
   _inputHtml() {
     return Object.assign({}, this.props.inputHtml, {

--- a/src/js/components/select.js
+++ b/src/js/components/select.js
@@ -7,12 +7,13 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 export default class Select extends React.Component {
   static displayName = 'FriggingBootstrap.Select'
 
-  static defaultProps = Object.assign({}, require('../default_props.js'), {
+  static defaultProps = Object.assign({}, defaultProps, {
     options: {},
   })
 

--- a/src/js/components/submit.js
+++ b/src/js/components/submit.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { sizeClassNames } from '../util.js'
 import cx from 'classnames'
+import defaultProps from '../default_props.js'
 
 export default class Submit extends React.Component {
   static displayName = 'FriggingBootstrap.Submit'
 
-  static defaultProps = Object.assign({}, require('../default_props.js'), {
+  static defaultProps = Object.assign({}, defaultProps, {
     bsStyle: 'default',
     bsSize: undefined,
     block: false,

--- a/src/js/components/switch.js
+++ b/src/js/components/switch.js
@@ -7,13 +7,14 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx, inputContainerCx } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Boolean
 export default class Switch extends React.Component {
   static displayName = 'FriggingBootstrap.Switch'
 
-  static defaultProps = Object.assign(require('../default_props.js'), {
+  static defaultProps = Object.assign(defaultProps, {
     onColor: 'primary',
     onText: 'ON',
     offColor: 'default',

--- a/src/js/components/switch.js
+++ b/src/js/components/switch.js
@@ -7,6 +7,7 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx, inputContainerCx } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Boolean
 export default class Switch extends React.Component {
@@ -22,28 +23,18 @@ export default class Switch extends React.Component {
     handleWidth: undefined,
   })
 
-  static propTypes = {
-    align: React.PropTypes.string,
-    onColor: React.PropTypes.string,
-    onText: React.PropTypes.string,
-    offColor: React.PropTypes.string,
-    offText: React.PropTypes.string,
-    bsSize: React.PropTypes.string,
-    disabled: React.PropTypes.bool,
-    handleWidth: React.PropTypes.number,
-
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      align: React.PropTypes.string,
+      onColor: React.PropTypes.string,
+      onText: React.PropTypes.string,
+      offColor: React.PropTypes.string,
+      offText: React.PropTypes.string,
+      bsSize: React.PropTypes.string,
+      disabled: React.PropTypes.bool,
+      handleWidth: React.PropTypes.number,
+    }
+  )
 
   constructor() {
     super()

--- a/src/js/components/text.js
+++ b/src/js/components/text.js
@@ -5,12 +5,13 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 export default class Text extends React.Component {
   static displayName = 'FriggingBootstrap.Text'
 
-  static defaultProps = Object.assign(require('../default_props.js'))
+  static defaultProps = defaultProps
 
   static propTypes = Object.assign({},
     defaultPropTypes, {

--- a/src/js/components/text.js
+++ b/src/js/components/text.js
@@ -5,28 +5,18 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 export default class Text extends React.Component {
   static displayName = 'FriggingBootstrap.Text'
 
   static defaultProps = Object.assign(require('../default_props.js'))
 
-  static propTypes = {
-    inputHtml: React.PropTypes.object,
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-
-    rows: React.PropTypes.number,
-    className: React.PropTypes.string,
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-  }
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      rows: React.PropTypes.number,
+    }
+  )
 
   _inputHtml() {
     return Object.assign({}, this.props.inputHtml, {

--- a/src/js/components/timepicker.js
+++ b/src/js/components/timepicker.js
@@ -8,17 +8,19 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Focusable
 export default class TimePicker extends React.Component {
   static displayName = 'FriggingBootstrap.TimePicker'
 
-  static defaultProps = Object.assign(require('../default_props.js'))
+  static defaultProps = defaultProps
 
   static propTypes = Object.assign({},
     defaultPropTypes, {
       focused: React.PropTypes.bool.isRequired,
+      inputHtml: React.PropTypes.object,
     }
   )
 

--- a/src/js/components/timepicker.js
+++ b/src/js/components/timepicker.js
@@ -8,6 +8,7 @@ import InputErrorList from './input_error_list'
 import Saved from './saved'
 import Label from './label'
 import { sizeClassNames, formGroupCx } from '../util.js'
+import defaultPropTypes from '../default_prop_types.js'
 
 @HigherOrderComponents.Focusable
 export default class TimePicker extends React.Component {
@@ -15,21 +16,11 @@ export default class TimePicker extends React.Component {
 
   static defaultProps = Object.assign(require('../default_props.js'))
 
-  // TODO: standarized proptyles accross componets
-  static propTypes = {
-    inputHtml: React.PropTypes.object,
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-    saved: React.PropTypes.bool,
-    errors: React.PropTypes.array,
-    focused: React.PropTypes.bool.isRequired,
-  }
+  static propTypes = Object.assign({},
+    defaultPropTypes, {
+      focused: React.PropTypes.bool.isRequired,
+    }
+  )
 
   _inputCx() {
     return cx(

--- a/src/js/components/timepicker_popup.js
+++ b/src/js/components/timepicker_popup.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { UnboundInput } from 'frig'
+import defaultProps from '../default_props.js'
 import defaultPropTypes from '../default_prop_types.js'
 
 export default class TimePickerPopup extends React.Component {
   static displayName = 'FriggingBootstrap.TimePickerPopup'
 
-  static defaultProps = Object.assign(require('../default_props.js'))
+  static defaultProps = defaultProps
 
   static propTypes = defaultPropTypes
 

--- a/src/js/components/timepicker_popup.js
+++ b/src/js/components/timepicker_popup.js
@@ -1,21 +1,13 @@
 import React from 'react'
 import { UnboundInput } from 'frig'
+import defaultPropTypes from '../default_prop_types.js'
 
 export default class TimePickerPopup extends React.Component {
   static displayName = 'FriggingBootstrap.TimePickerPopup'
 
   static defaultProps = Object.assign(require('../default_props.js'))
 
-  static propTypes = {
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-      ]),
-      requestChange: React.PropTypes.func,
-    }).isRequired,
-  }
+  static propTypes = defaultPropTypes
 
   // Returns the number of hours from 12 to 1 to 11
   _getHour(minutesSinceMidnight = this._minutesSinceMidnight()) {

--- a/src/js/default_prop_types.js
+++ b/src/js/default_prop_types.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const propTypes = {
+  valueLink: React.PropTypes.shape({
+    value: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number,
+      React.PropTypes.bool,
+    ]),
+    requestChange: React.PropTypes.func,
+  }).isRequired,
+  inputHtml: React.PropTypes.object,
+  className: React.PropTypes.string,
+  saved: React.PropTypes.bool,
+  errors: React.PropTypes.array,
+}
+
+export default propTypes

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -36,7 +36,8 @@ const inputContainerCx = (props) => {
 }
 
 const formGroupCx = (props) => {
-  const isCheckbox = props.inputHtml.type === 'checkbox'
+  const { inputHtml } = props
+  const isCheckbox = inputHtml ? inputHtml.type === 'checkbox' : false
 
   return cx(Object.assign({
     'form-group': !isCheckbox,

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -84,6 +84,17 @@ describe('Util', () => {
         const result = formGroupCx(props)
         expect(result).to.equal('form-group')
       })
+      it('should return form-goup if inputHtml is has no type', () => {
+        const props = {
+          inputHtml: {},
+        }
+        const result = formGroupCx(props)
+        expect(result).to.equal('form-group')
+      })
+      it('should return form-goup if no inputHtml', () => {
+        const result = formGroupCx({})
+        expect(result).to.equal('form-group')
+      })
       it('should set has-error if props.errors is not undefined', () => {
         const props = {
           inputHtml: {


### PR DESCRIPTION
- Add Default prop types to each of the input components because all of the input components share common prop types.
- Move Default props to top of the component because Airbnb has added the
  [ESLinit rule](http://eslint.org/docs/rules/global-require) to force all require files to be at the top of the file.
  This will make sure that the require files are all together on top of
  the file.
