### PR TITLE
Revert "Update eslint-plugin-jsx-a11y to version 2.0.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint": "2.13.1",
     "eslint-config-airbnb": "9.0.1",
     "eslint-plugin-import": "1.10.3",
-    "eslint-plugin-jsx-a11y": "2.0.0",
+    "eslint-plugin-jsx-a11y": "1.5.5",
     "eslint-plugin-react": "5.2.2",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",


### PR DESCRIPTION
eslint-config-airbnb still eslint-plugin-jsx-a11y version requires 1.5.5 as it does not support ESLint 3.0 yet.
