### PR TITLE
Revert "Update eslint to version 3.2.2 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "css-loader": "0.23.1",
     "dirty-chai": "1.2.2",
     "enzyme": "2.4.1",
-    "eslint": "3.2.2",
+    "eslint": "2.13.1",
     "eslint-config-airbnb": "9.0.1",
     "eslint-plugin-import": "1.12.0",
     "eslint-plugin-jsx-a11y": "1.5.5",


### PR DESCRIPTION
Until `eslint-plugin-react` version 6.0 fixes 

```
Configuration for rule "react/jsx-uses-react" is invalid:  
Value "[object Object]" has more items than allowed.
```

As this blocks updates from `eslint` & `eslint-config-airbnb` since they both need `eslint-plugin-react` package.
